### PR TITLE
Fix bug in link show live

### DIFF
--- a/app/views/lives/index.html.erb
+++ b/app/views/lives/index.html.erb
@@ -13,7 +13,7 @@
   <tbody>
     <% @lives.each do |live| %>
       <tr>
-        <td><%= link_to live.subject, live %></td>
+        <td><%= live.subject %></td>
         <td><%= live.description %></td>
         <td><%= live.author.name %></td>
 


### PR DESCRIPTION
If applied, this commit removes the live show link in View lives index