### PR TITLE
Let users delete own unvotted lives

### DIFF
--- a/app/controllers/lives_controller.rb
+++ b/app/controllers/lives_controller.rb
@@ -2,7 +2,7 @@
 
 class LivesController < ApplicationController
   before_action :set_live, only: %i[edit update destroy]
-  before_action :check_live_ownership, only: %i[edit]
+  before_action :check_live_ownership, only: %i[edit destroy]
 
   def index
     @lives = Live.order(votes_count: :desc, created_at: :desc)
@@ -32,6 +32,20 @@ class LivesController < ApplicationController
     else
       flash.now[:alert] = @live.errors.full_messages.to_sentence
       render :edit
+    end
+  end
+
+  def destroy
+    unless @live.can_be_deleted?
+      redirect_to lives_path, alert: 'Você só pode remover sugestões com zero votos'
+      return
+    end
+
+    if @live.destroy
+      redirect_to lives_path, notice: 'Sugestão de Live foi removida com sucesso.'
+    else
+      flash.now[:alert] = @live.errors.full_messages.to_sentence
+      render :index
     end
   end
 

--- a/app/controllers/lives_controller.rb
+++ b/app/controllers/lives_controller.rb
@@ -2,6 +2,7 @@
 
 class LivesController < ApplicationController
   before_action :set_live, only: %i[edit update destroy]
+  before_action :check_live_ownership, only: %i[edit]
 
   def index
     @lives = Live.order(votes_count: :desc, created_at: :desc)
@@ -12,11 +13,7 @@ class LivesController < ApplicationController
     @live = Live.new
   end
 
-  def edit
-    if @live.author != current_user
-      redirect_to lives_path, alert: 'Você não tem permissão para editar essa live'
-    end
-  end
+  def edit; end
 
   def create
     @live = Live.new(live_params.merge(author: current_user))
@@ -46,5 +43,11 @@ class LivesController < ApplicationController
 
   def live_params
     params.require(:live).permit(:subject, :description)
+  end
+
+  def check_live_ownership
+    if @live.author != current_user
+      redirect_to lives_path, alert: 'Você não tem permissão para editar/remover essa live'
+    end
   end
 end

--- a/app/models/live.rb
+++ b/app/models/live.rb
@@ -6,4 +6,8 @@ class Live < ApplicationRecord
   belongs_to :author, class_name: 'User'
 
   has_many :votes
+
+  def can_be_deleted?
+    votes_count.zero?
+  end
 end

--- a/app/views/lives/index.html.erb
+++ b/app/views/lives/index.html.erb
@@ -9,6 +9,7 @@
       <th class='author'><%= t 'activerecord.attributes.live.author' %></th>
       <th class='created_at'><%= t 'activerecord.attributes.live.created_at' %></th>
       <th></th>
+      <th></th>
     </tr>
   </thead>
 
@@ -46,6 +47,12 @@
         <td>
           <% if live.author == current_user %>
             <%= link_to 'Editar', edit_live_path(live), class: 'button is-success is-small' %>
+          <% end %>
+        </td>
+
+        <td>
+          <% if live.author == current_user and live.can_be_deleted? %>
+            <%= link_to 'Remover', live_path(live), method: :delete, data: { confirm: 'Você tem certeza?' }, class: 'button is-danger is-small' %>
           <% end %>
         </td>
       </tr>

--- a/app/views/lives/index.html.erb
+++ b/app/views/lives/index.html.erb
@@ -51,7 +51,7 @@
         </td>
 
         <td>
-          <% if live.author == current_user and live.can_be_deleted? %>
+          <% if live.author == current_user && live.can_be_deleted? %>
             <%= link_to 'Remover', live_path(live), method: :delete, data: { confirm: 'Você tem certeza?' }, class: 'button is-danger is-small' %>
           <% end %>
         </td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
 
   devise_for :users
 
-  resources :lives, except: %i[show destroy]
+  resources :lives, except: %i[show]
   resources :votes, only: %i[create destroy]
 end

--- a/spec/models/live_spec.rb
+++ b/spec/models/live_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Live do
+  describe '#can_be_deleted?' do
+    let(:live) { create(:live) }
+    let(:user) { create(:user) }
+
+    it 'returns true for lives with no votes' do
+      expect(live.can_be_deleted?).to be true
+    end
+
+    it 'returns false for lives with at least one vote' do
+      Vote.create! live: live, user: user
+      expect(live.can_be_deleted?).to be false
+    end
+  end
+end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -10,4 +10,10 @@ FactoryBot.define do
     password_confirmation { 'secret1234' }
     confirmed_at { Time.current }
   end
+
+  factory :live do
+    subject { 'Introduction to Springfield' }
+
+    association :author, factory: :user
+  end
 end


### PR DESCRIPTION
Hi @lucascaton, motivated by that accidental duplication (when both of us were adding the same list of suggestions to easy-lives) I've decided to implement the "delete" feature, as I suppose you wouldn't want to implement it during one of the lives, since there is nothing really new that could be of interest to viewers.

### What is introduced by this PR?

* The rule for allowing or not a Live to be deleted (described in bde4600 commit body)
* An exposed endpoint (`DELETE /lives/:id`)
* A controller action (`lives#destroy`) that:
  * Checks if current user actually owns the live about to be deleted;
  * Checks if the live can be deleted, according to the rule mentioned above;
  * If is all good, perform the deletion;
* A "delete" button on the main (`lives#index`) page, that is only presented for lives elegible for deletion;
  * A confirmation alert on click, just for sanity check.

### How does it look like?

![delete-button-on-list-page](https://user-images.githubusercontent.com/190616/59126917-8d315200-8966-11e9-8cc8-f33a2f69877d.png)