### PR TITLE
Add Dockerized environment

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,6 @@
+# DB_URI and DB_TEST_URI are environment variables to setup the database
+DB_URI=postgres://postgres:@db/easy-lives
+DB_TEST_URI=postgres://postgres:@db/easy-lives_test
+
+# RAILS_LOG_TO_STDOUT is the Rails's env variable used to print out logs
+RAILS_LOG_TO_STDOUT=true

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 
 # RSpec files
 /spec/examples.txt
+
+# ENV files
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ruby:2.6.3-alpine
+
+ARG APP_DIR=/usr/src/app/
+
+RUN apk update && apk upgrade && \
+  apk add bash build-base libxml2-dev libxslt-dev curl yarn postgresql-libs postgresql-client postgresql-dev tzdata && \
+  apk upgrade --available && \
+  rm -rf /var/cache/apk/*
+
+RUN mkdir -p $APP_DIR
+
+WORKDIR $APP_DIR
+
+COPY Gemfile* $APP_DIR
+
+RUN bundle install --jobs `expr $(cat /proc/cpuinfo | grep -c "cpu cores") - 1` --retry 3
+
+COPY package.json $APP_DIR
+COPY yarn.lock $APP_DIR
+
+RUN yarn install --production && \
+  yarn install --check-files
+
+COPY . $APP_DIR

--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@
 Aplicação criada nas [lives do Lucas Caton](https://www.lucascaton.com.br/lives).
 
 Assista em: [youtube.com/lucascaton](https://www.youtube.com/lucascaton?sub_confirmation=1)!
+
+### Contribuindo para este projeto
+
+#### Usando Docker
+
+Faça uma cópia do `.env.sample` e configure caso desejado. Execute o seguinte comando:
+
+```
+docker-compose pull &&
+docker-compose up -d --no-deps --build &&
+docker-compose run --rm app rails db:create db:migrate
+```

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,7 +23,8 @@ default: &default
 
 development:
   <<: *default
-  database: easy-lives_development
+  url: <%= ENV.fetch('DB_URI', 'localhost') %>
+  database: <%= ENV.fetch('DB_NAME', 'easy-lives_development') %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -57,7 +58,8 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: easy-lives_test
+  url: <%= ENV.fetch('DB_TEST_URI', 'localhost') %>
+  database: <%= ENV.fetch('DB_NAME', 'easy-lives_test') %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.6'
+services:
+
+  app:
+    build: .
+    container_name: easy-lives-app
+    command: bin/rails server --port 3000 --binding 0.0.0.0
+    ports:
+      - 3000:3000
+    volumes:
+      - .:/usr/src/app
+      - gems:/usr/local/bundle
+      - home:/home/app
+    networks:
+      - net
+    depends_on:
+      - db
+    env_file: .env
+    tty: true
+    stdin_open: true
+
+  db:
+    image: postgres:10.5
+    container_name: easy-lives-db
+    volumes:
+      - database:/var/lib/postgresql/data
+    ports:
+      - 5433:5432
+    networks:
+      - net
+
+volumes:
+  database:
+  gems:
+  home:
+
+networks:
+  net:


### PR DESCRIPTION
### What does this PR do?

This PR adds support to Docker on development.

#### Bulding Process

![Peek 2019-08-12 23-36](https://user-images.githubusercontent.com/13566315/62911249-121b5c00-bd5a-11e9-82d9-151d84dd0814.gif)
_(starting build process)_

![Peek 2019-08-12 23-43](https://user-images.githubusercontent.com/13566315/62911527-185e0800-bd5b-11e9-97d1-ee5d89f8cf8a.gif)
_(build process finished and loading the application)_

### How to test it?

Make sure you have Docker and Docker Compose properly installed. Then just run

```
docker-compose pull &&
docker-compose run --rm app bundle install &&
docker-compose run --rm app npm install bulma bulma-tooltip &&
docker-compose run --rm app rake db:create &&
docker-compose run --rm app rake db:migrate &&
docker-compose up
```

You can access `easy-lives` at `localhost:3000`